### PR TITLE
Add the domain ID to the domain info

### DIFF
--- a/src/VirtualminApi.php
+++ b/src/VirtualminApi.php
@@ -48,6 +48,7 @@ class VirtualminApi
             $domains[] = [
                 'server'           => $this->server['hostname'],
                 'name'             => $domain->name,
+                'id'               => $domain->values->id[0],
                 'type'             => $this->getHostingType($domain),
                 'username'         => $domain->values->username[0] ?? '',
                 'password'         => $domain->values->password[0] ?? '',


### PR DESCRIPTION
The domain ID is used to interact with a lot of plugins. Adding this information would enable developer to call different plugins in the virtualmin.